### PR TITLE
Proposal to remove py36 environment from tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,6 @@ jobs:
     strategy:
       matrix:
         tox_env:
-          - py36
           - py37
           - py38
           - py39

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,6 @@ queue_rules:
   - "#changes-requested-reviews-by=0"
   - status-success=Checks
   - status-success=Documentation
-  - status-success=Unit tests (py36)
   - status-success=Unit tests (py37)
   - status-success=Unit tests (py38)
   - status-success=Unit tests (py39)
@@ -31,7 +30,6 @@ pull_request_rules:
   - status-success=DCO
   - status-success=Checks
   - status-success=Documentation
-  - status-success=Unit tests (py36)
   - status-success=Unit tests (py37)
   - status-success=Unit tests (py38)
   - status-success=Unit tests (py39)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,7 @@ repos:
     rev: v2.32.1
     hooks:
       - id: pyupgrade
-        args:
-          - --py36-plus
+        args: [--py36-plus]
 
   - repo: https://github.com/psf/black
     rev: 22.3.0

--- a/news/get-authors.py
+++ b/news/get-authors.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
 """
-This script browses through git commit history (starting at latest tag), collects all authors of
-commits and creates fragment for `towncrier`_ tool.
+This script browses through git commit history (starting at latest tag),
+collects all authors of commits and creates fragment for `towncrier`_ tool.
 
-It's meant to be run during the release process, before generating the release notes.
+It's meant to be run during the release process,
+before generating the release notes.
 
 Example::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ lines_after_imports = 2
 force_alphabetical_sort_within_sections = true
 
 [tool.black]
-target-version = ["py36"]
+target-version = ["py37"]
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = checks,docs,licenses,covclean,{py36,py37,py38,py39}-unittest,covreport
+envlist = checks,docs,licenses,covclean,{py37,py38,py39}-unittest,covreport
 isolated_build = true
 requires =
     poetry
@@ -11,8 +11,8 @@ sitepackages = false
 commands =
     unittest: pytest -vv --cov --cov-append --cov-report= tests {posargs}
 depends =
-    {py36,py37,py38,py39}: covclean
-    covreport: py36-unittest,py37-unittest,py38-unittest,py39-unittest
+    {py37,py38,py39}: covclean
+    covreport: py37-unittest,py38-unittest,py39-unittest
 
 [testenv:covreport]
 basepython = python3.9


### PR DESCRIPTION
We might not need python 3.6 testing environment.
Proposal to remove py36 from CI.

Should fix the CI. 